### PR TITLE
rubima-lintに対してクラス化と警告内容の表示をするようにしました

### DIFF
--- a/tools/rubima-lint.rb
+++ b/tools/rubima-lint.rb
@@ -1,120 +1,182 @@
-#!/usr/bin/ruby -Ku
-# -*- coding: utf-8 -*-
-# 正規表現エンジンに鬼車必須
-# [ruby-list:41932]を参考にした。
-#使い方 チェックしたい Hiki ソースをテキスト(例 hoge.txt) に保存。
-#$ ruby rubima-lint.rb hoge.txt でエラー行数・エラー内容が出力されます。
+#!/usr/bin/env ruby
 
-非ascii = '[^[:ascii:]]'
-ascii = '[\w&&[:ascii:]]'
-開き丸括弧 = '[(]'
-閉じ丸括弧 = '[)]'
-疑問符・感嘆符 = '[？！]'
-句読点 = "[、。#{疑問符・感嘆符}]"
-開き括弧類 = '[「『]'
-閉じ括弧類 = '[』」]'
-三点リーダ = '[…]'
-その他ok文字 = "[#{三点リーダ}〜：　]"
-asciiの直前ok文字 = "[#{句読点}#{開き括弧類}#{その他ok文字}]"
-asciiの直後ok文字 = "[#{句読点}#{閉じ括弧類}#{その他ok文字}]"
-発言頭 = "'''　"
-非asciiの直後にascii = /(?<=#{非ascii})(?=#{ascii})(?<!#{asciiの直前ok文字})(?<!#{発言頭})/o
-asciiの直後に非ascii = /(?<=#{ascii})(?=#{非ascii})(?!#{asciiの直後ok文字})/o
-空白抜け = /#{非asciiの直後にascii}|#{asciiの直後に非ascii}/o
+class RubimaLint
+  NOT_ASCII  = '[^[:ascii:]]'     # 非ASCII
+  ASCII_CHAR = '[\w&&[:ascii:]]'  # ASCII
+  OPEN_PARENTHESES  = '[(]'  # 開き丸括弧
+  CLOSE_PARENTHESES = '[)]'  # 閉じ丸括弧
+  QUESTION_EXCLAMATION = '[？！]'  # 疑問符・感嘆符
+  PUNCTUATION = "[、。#{QUESTION_EXCLAMATION}]"  # 句読点
+  OPEN_BRANCKETS  = '[「『]'  # 開き括弧類
+  CLOSE_BRANCKETS = '[』」]'  # 閉じ括弧類
+  THREE_POINT_LEADER = '[…]'  # 三点リーダ
+  OTHER_OK_LETTER = "[#{THREE_POINT_LEADER}〜：　]"  # その他OK文字
+  OK_BEFORE_ASCII = "[#{PUNCTUATION}#{OPEN_BRANCKETS}#{OTHER_OK_LETTER}]"  # ASCII直前のOK文字
+  OK_AFTER_ASCII = "[#{PUNCTUATION}#{CLOSE_BRANCKETS}#{OTHER_OK_LETTER}]"  # ASCII直後のOK文字
+  HEAD_CHAR = "'''　"  # 発言頭
+  ASCII_AFTER_NOT_ASCII = /(?<=#{NOT_ASCII})(?=#{ASCII_CHAR})(?<!#{OK_BEFORE_ASCII})(?<!#{HEAD_CHAR})/o  # 非ASCIIの直後にASCII
+    NOT_ASCII_AFTER_ASCII = /(?<=#{ASCII_CHAR})(?=#{NOT_ASCII})(?!#{OK_AFTER_ASCII})/o  # ASCIIの直後に非ASCII
+    MISSING_BLANK = /#{ASCII_AFTER_NOT_ASCII}|#{NOT_ASCII_AFTER_ASCII}/o  # 空白抜け
 
-丸括弧前後ok文字 = "[ [[:ascii:]&&[:graph:]]#{句読点}#{開き括弧類}#{閉じ括弧類}#{三点リーダ}]"
+  # 円括弧前後OK文字
+  OK_AROUND_PARENTHESES = "[ [[:ascii:]&&[:graph:]]#{PUNCTUATION}#{OPEN_BRANCKETS}#{CLOSE_BRANCKETS}#{THREE_POINT_LEADER}]"
 
-union = [
-  /(?<!^)(?<!#{発言頭})(?<!#{丸括弧前後ok文字})#{開き丸括弧}/o,
-  /#{閉じ丸括弧}(?!#{丸括弧前後ok文字})(?!$)/o,
-  文末で括弧を閉じる場合 = /。#{閉じ丸括弧}。/o,
-  括弧笑の後の句点 = /笑#{閉じ丸括弧}。$/o,
-  単独の三点リーダ = /(?<!#{三点リーダ})#{三点リーダ}(?!#{三点リーダ})/o,
-  文末の三点リーダ = /#{三点リーダ}$/o,
-  段落中の疑問符・感嘆符 = /#{疑問符・感嘆符}(?!$)(?![　#{疑問符・感嘆符}#{閉じ括弧類}])/o,
-  全角括弧 = /[（）]/o,
-]
-invalid_pattern = Regexp.union(*union)
+  union = [
+    /(?<!^)(?<!#{HEAD_CHAR})(?<!#{OK_AROUND_PARENTHESES})#{OPEN_PARENTHESES}/o,
+    /#{CLOSE_PARENTHESES}(?!#{OK_AROUND_PARENTHESES})(?!$)/o,
+    PARENTHESES_AT_END_OF_STATE = /。#{CLOSE_PARENTHESES}。/o,  # 文末で括弧を閉じる場合
+      LAUGH_AND_PARENTHESES = /笑#{CLOSE_PARENTHESES}。$/o,    # 括弧笑の後の句点
+      SINGLE_THREE_POINT_LEADER = /(?<!#{THREE_POINT_LEADER})#{THREE_POINT_LEADER}(?!#{THREE_POINT_LEADER})/o,  # 単独の三点リーダ
+      THREE_POINT_LEADER_AT_END = /#{THREE_POINT_LEADER}$/o,  # 文末の三点リーダ
+    QUESTION_EXCLAMATION_IN_PARAGRAPH = /#{QUESTION_EXCLAMATION}(?!$)(?![　#{QUESTION_EXCLAMATION}#{CLOSE_BRANCKETS}])/o,  # 段落中の疑問符・感嘆符
+    FULL_WIDTH_PARENTHESES = /[（）]/o,  # 全角括弧
+  ]
+  INVALID_PATTERN = Regexp.union(*union)
 
-括弧の前後にあると空白を入れない文字 = "[#{句読点}#{開き括弧類}#{閉じ括弧類}]"
-union = [
-  /#{三点リーダ} #{開き丸括弧}/o,
-  /#{括弧の前後にあると空白を入れない文字} #{開き丸括弧}/o,
-  /#{閉じ丸括弧} #{括弧の前後にあると空白を入れない文字}/o,
-]
-不要な空白 = Regexp.union(*union)
+  CHAR_AROUND_NOT_PERMIT_BLANK = "[#{PUNCTUATION}#{OPEN_BRANCKETS}#{CLOSE_BRANCKETS}]"
+  union = [
+    /#{THREE_POINT_LEADER} #{OPEN_PARENTHESES}/o,
+    /#{CHAR_AROUND_NOT_PERMIT_BLANK} #{OPEN_PARENTHESES}/o,
+    /#{CLOSE_PARENTHESES} #{CHAR_AROUND_NOT_PERMIT_BLANK}/o,
+  ]
+  INVALID_BLANK = Regexp.union(*union)
 
-count = 0
-fn = false
-last_hrule = false
-toc_check = false
-STDOUT.set_encoding(Encoding.locale_charmap)
-ARGF.each do |line|
-  matched = false
-  line.gsub!(空白抜け) do
-    matched = true
-    count += 1
-    "\e[7m \e[m"
+  attr_reader :warning_count, :error_messages
+
+  def initialize(options)
+    @warning_count = 0
+    @warning_messages = []
+    @options = options
+    @fn = false
+    @last_hrule = false
   end
-  line.gsub!(invalid_pattern) do
-    matched = true
-    count += 1
-    "\e[31m#{$&}\e[m"
+
+  def run!
+    @options.each_line do |line|
+      white_space_check(@options.lineno, line)
+      invalid_pattern_check(@options.lineno, line)
+      unnecessary_space_check(@options.lineno, line)
+      todo_check(@options.lineno, line)
+      link_check(@options.lineno, line)
+      toc_check(@options.lineno, line)
+
+      footnote_check(@options.lineno, line)
+      last_hrule_check(@options.lineno, line)
+    end
+
+    footnote_pair_check
+
+    @warning_count > 0
   end
-  line.gsub!(不要な空白) do
-    matched = true
-    count += 1
-    "\e[32m#{$&}\e[m"
-  end
-  line.gsub!(/TODO/) do
-    matched = true
-    count += 1
-    "\e[33m#{$&}\e[m"
-  end
-  line.gsub!(/(?<left>\[\[(.*?\|)?)(?<link>.*)(?<right>\]\])/) do
-    m = $~
-    case m[:link]
-    when %r!\Ahttps?://!
-      $&
-    when /[^0-9A-Za-z\-_]/
-      matched = true
-      count += 1
-      "#{m[:left]}\e[34m#{m[:link]}\e[m#{m[:right]}"
+
+  def print_result
+    if @warning_count > 0
+      puts "#{@warning_count} warning(s)"
+      @warning_messages.each do |warning_message|
+        puts warning_message
+      end
+      false
     else
-      $&
+      true
     end
   end
-  line.gsub!(/\{\{toc\}\}/) do
-    matched = true
-    count += 1
-    toc_check = true
-    "\e[35m#{$&}\e[m"
-  end
-  if matched
-    puts "#{ARGF.lineno}:#{line}"
+
+  def add_msg(msg)
+    @warning_messages << msg
+    msg
   end
 
-  if /\{\{fn/ =~ line
-    fn = true
+  def white_space_check(lineno, line)
+    check_result = false
+    line.gsub!(MISSING_BLANK) do
+      check_result = true
+      @warning_count += 1
+      "\e[7m \e[m"
+    end
+    add_msg("半角英数字の前後には空白が必要です。: #{lineno}行目 : #{line}") if check_result
   end
-  if /^----$/ =~ line
-    last_hrule = true
-  elsif /\S/ =~ line
-    last_hrule = false
+
+  def invalid_pattern_check(lineno, line)
+    check_result = false
+    line.gsub!(INVALID_PATTERN) do
+      check_result = true
+      @warning_count += 1
+      "\e[31m#{$&}\e[m"
+    end
+    add_msg("句点や括弧の記述が編集指針にあいません。 : #{lineno}行目 : #{line}") if check_result
   end
+
+  def unnecessary_space_check(lineno, line)
+    check_result = false
+    line.gsub!(INVALID_BLANK) do
+      check_result = true
+      @warning_count += 1
+      "\e[32m#{$&}\e[m"
+    end
+    add_msg("不要な空白が含まれています。 : #{lineno}行目 : #{line}") if check_result
+  end
+
+  def todo_check(lineno, line)
+    check_result = false
+    line.gsub!(/TODO/) do
+      check_result = true
+      @warning_count += 1
+      "\e[33m#{$&}\e[m"
+    end
+    add_msg("TODOが含まれています。 : #{lineno}行目 : #{line}") if check_result
+  end
+
+  def link_check(lineno, line)
+    check_result = false
+    line.gsub!(/(?<left>\[\[(.*?\|)?)(?<link>.*)(?<right>\]\])/) do
+      m = $~
+      if m[:link] !~ %r!\Ahttps?://! &&  m[:link] =~ /[^0-9A-Za-z\-_]/
+        check_result = true
+        @warning_count += 1
+        "#{m[:left]}\e[34m#{m[:link]}\e[m#{m[:right]}"
+      end
+    end
+    add_msg("リンクの設定漏れと思われる部分があります。 : #{lineno}行目 : #{line}") if check_result
+  end
+
+  def toc_check(lineno, line)
+    check_result = false
+    line.gsub!(/\{\{toc\}\}/) do
+      check_result = true
+      @warning_count += 1
+      "\e[35m#{$&}\e[m"
+    end
+    add_msg("{{toc}}ではなく、{{toc_here}}を使ってください。 : #{lineno}行目 : #{line}") if check_result
+  end
+
+  def footnote_check(lineno, line)
+    @fn = true if /\{\{fn/ =~ line
+  end
+
+  def last_hrule_check(lineno, line)
+    if /^----$/ =~ line
+      @last_hrule = true
+    elsif /\S/ =~ line
+      @last_hrule = false
+    end
+  end
+
+  def footnote_pair_check
+    if @fn && !@last_hrule
+      @warning_count += 1
+      add_msg("\e[7m脚注があるのに末尾に「----」がありません。\e[m")
+    elsif !@fn && @last_hrule
+      @warning_count += 1
+      add_msg("\e[7m脚注がないのに末尾に「----」があります。\e[m")
+    end
+  end
+
 end
 
-if fn and not last_hrule
-  count += 1
-  puts "\e[7m脚注があるのに末尾に「----」がない。\e[m"
-elsif not fn and last_hrule
-  count += 1
-  puts "\e[7m脚注がないのに末尾に「----」がある。\e[m"
+if $0 == __FILE__
+  checker = RubimaLint.new(ARGF)
+  checker.run!
+
+  exit(checker.print_result)
 end
 
-puts "\e[35m{{toc}}\e[mの代わりに\e[35m{{toc_here}}\e[mを使ってください" if toc_check
-
-if 0 < count
-  puts "#{count} warning(s)"
-  exit(false)
-end


### PR DESCRIPTION
Pull Request #255. を契機に、クラス化を行いました。
また、実際に使っていて警告の内容が分かりにくかったので、警告内容を表示するようにしました。

次のように出力されます。

> [~/work/rubima/tools]$ ./rubima-lint.rb case01.txt
> 1 warning(s)
> TODOが含まれています。 : 186行目 : ひとまず TODO の summary と description の項目を
> [~/work/rubima/tools]$
