### PR TITLE
スケジュールと今後の発行予定を表に統合

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,34 +8,23 @@ If you need any support, please create an issue to the Rubyist Magazine support 
 
 次号スケジュールは Issue に書くようになりました。
 
-* 56 号 : https://github.com/rubima/rubima/issues/432
-* 55 号 : https://github.com/rubima/rubima/issues/418
-* 54 号 : https://github.com/rubima/rubima/issues/402
-* 東京 Ruby 会議 11 特別号 : https://github.com/rubima/rubima/issues/398
-* 53 号 : https://github.com/rubima/rubima/issues/386
-* 52 号 : https://github.com/rubima/rubima/issues/369
-* 51 号 : https://github.com/rubima/rubima/issues/353
-* 50 号 : https://github.com/rubima/rubima/issues/324
-* 49 号 : https://github.com/rubima/rubima/issues/304
-* 48 号 : https://github.com/rubima/rubima/issues/291
-* 47 号 : https://github.com/rubima/rubima/issues/279
-* 46 号 : https://github.com/rubima/rubima/issues/252
+今後の発行予定はあくまで編集者内部の予定です。意気込みとかこうだったらいいな、くらいのニュアンスです。
 
-
-## 今後の発行予定
-
-あくまで編集者内部の予定です。意気込みとかこうだったらいいな、くらいのニュアンスです。
-
-* 2013/12 - 45 号
-* 2014/03 - 46 号
-* 2014/06 - 47 号
-* 2014/09 - 48 号 10 周年!!
-* 2014/12 - 49 号
-* 2015/05 - 50 号
-* 2015/09 - 51 号
-* 2015/12 - 52 号
-* 2016/04 - 53 号
-* 2016/05 - 東京 Ruby 会議 11 特別号
-* 2016/08 - 54 号
-* 2017/03 - 55 号
-* 2017/08 - 56 号
+| 発行予定 | 号数 | Issue |
+| -------- | ---- | ----- |
+| 2018/02 | Ruby25周年記念イベントの事後特集号 | https://github.com/rubima/rubima/issues/450 |
+| [2018/01](https://github.com/rubima/rubima/issues/435#issuecomment-323501175) | 0057 号 | 未定 |
+| 2017/09 | RubyKaigi 2017直前特集号 | https://github.com/rubima/rubima/issues/445 |
+| 2017/08 | 0056 号 | https://github.com/rubima/rubima/issues/432 |
+| 2017/03 | 0055 号 | https://github.com/rubima/rubima/issues/418 |
+| 2016/08 | 0054 号 | https://github.com/rubima/rubima/issues/402 |
+| 2016/05 | 東京 Ruby 会議 11 特別号 | https://github.com/rubima/rubima/issues/398 |
+| 2016/04 | 0053 号 | https://github.com/rubima/rubima/issues/386 |
+| 2015/12 | 0052 号 | https://github.com/rubima/rubima/issues/369 |
+| 2015/09 | 0051 号 | https://github.com/rubima/rubima/issues/353 |
+| 2015/05 | 0050 号 | https://github.com/rubima/rubima/issues/324 |
+| 2014/12 | 0049 号 | https://github.com/rubima/rubima/issues/304 |
+| 2014/09 | 0048 号 10 周年!! | https://github.com/rubima/rubima/issues/291 |
+| 2014/06 | 0047 号 | https://github.com/rubima/rubima/issues/279 |
+| 2014/03 | 0046 号 | https://github.com/rubima/rubima/issues/252 |
+| 2013/12 | 0045 号 | https://github.com/rubima/rubima/issues/221 |


### PR DESCRIPTION
- 号数部分が二重管理になっていたので統合
- 項目が3個以上になるので GFM の table に変更
- 号数を正式な番号の4桁に変更
- 今後の予定もわかる範囲で追加